### PR TITLE
velocity_vectors array to replace C{i}vel variables

### DIFF
--- a/rpgpy/header.py
+++ b/rpgpy/header.py
@@ -119,17 +119,7 @@ def read_rpg_header(file_name: str) -> Tuple[dict, int]:
 
         if level == 0:
             # adding velocity vectors for each chirp
-            velocity_vectors = []
-            for c in range(n_chirp):
-                n_bins = header['SpecN'][c]
-                n_bins_max = np.max(header['SpecN'])
-                bins_to_shift = (n_bins_max - n_bins)//2
-                dopp_res = np.divide(2.0 * header['MaxVel'][c], n_bins)
-                velocity_vectors.append(np.hstack((np.repeat(-999., bins_to_shift),
-                                                   np.linspace(-header['MaxVel'][c] + (0.5 * dopp_res),
-                                                               +header['MaxVel'][c] - (0.5 * dopp_res),
-                                                               n_bins),
-                                                   np.repeat(-999., bins_to_shift))))
+            velocity_vectors = utils.create_velocity_vectors(n_chirp, header)
             header['velocity_vectors'] = np.array(velocity_vectors)
 
     file_position = file.tell()

--- a/rpgpy/header.py
+++ b/rpgpy/header.py
@@ -113,10 +113,15 @@ def read_rpg_header(file_name):
 
             velocity_vectors = []
             for c in range(n_chirp):
-                dopp_res = np.divide(2.0 * header['MaxVel'][c], header['SpecN'][c])
-                velocity_vectors.append(np.linspace(-header['MaxVel'][c] + (0.5 * dopp_res),
-                                                   +header['MaxVel'][c] - (0.5 * dopp_res),
-                                                   np.max(header['SpecN'])))
+                n_bins = header['SpecN'][c]
+                n_bins_max = np.max(header['SpecN'])
+                bins_to_shift = (n_bins_max - n_bins)//2
+                dopp_res = np.divide(2.0 * header['MaxVel'][c], n_bins)
+                velocity_vectors.append(np.hstack((np.repeat(-999., bins_to_shift),
+                                                   np.linspace(-header['MaxVel'][c] + (0.5 * dopp_res),
+                                                               +header['MaxVel'][c] - (0.5 * dopp_res),
+                                                               n_bins),
+                                                   np.repeat(-999., bins_to_shift))))
             header['velocity_vectors'] = np.array(velocity_vectors)
 
     file_position = file.tell()

--- a/rpgpy/header.py
+++ b/rpgpy/header.py
@@ -111,12 +111,13 @@ def read_rpg_header(file_name):
             _ = np.fromfile(file, 'i4', 25)
             _ = np.fromfile(file, 'uint32', 10000)
 
-            # adding velocity vectors for each chirp
+            velocity_vectors = []
             for c in range(n_chirp):
                 dopp_res = np.divide(2.0 * header['MaxVel'][c], header['SpecN'][c])
-                header[f'C{c+1}vel'] = np.linspace(-header['MaxVel'][c] + (0.5 * dopp_res),
+                velocity_vectors.append(np.linspace(-header['MaxVel'][c] + (0.5 * dopp_res),
                                                    +header['MaxVel'][c] - (0.5 * dopp_res),
-                                                   np.max(header['SpecN']))
+                                                   np.max(header['SpecN'])))
+            header['velocity_vectors'] = np.array(velocity_vectors)
 
     file_position = file.tell()
     file.close()

--- a/rpgpy/metadata.py
+++ b/rpgpy/metadata.py
@@ -377,26 +377,10 @@ METADATA = {
         name='kurtosis',
         long_name='Spectral Kurtosis',
         comment='vertical polarisation'),
-    'C1vel': Meta(
-        name='C1_velocity',
-        units='m/s',
-        long_name='Chirp 1 Doppler velocity bins',
-        comment='interpolated to maximum Doppler resolution'),
-    'C2vel': Meta(
-        name='C2_velocity',
-        units='m/s',
-        long_name='Chirp 2 Doppler velocity bins',
-        comment='interpolated to maximum Doppler resolution'),
-    'C3vel': Meta(
-        name='C3_velocity',
-        units='m/s',
-        long_name='Chirp 3 Doppler velocity bins',
-        comment='interpolated to maximum Doppler resolution'),
-    'C4vel': Meta(
-        name='C4_velocity',
-        units='m/s',
-        long_name='Chirp 4 Doppler velocity bins',
-        comment='interpolated to maximum Doppler resolution'),
+    'velocity_vectors': Meta(
+        name='velocity_vectors',
+        long_name='Doppler velocity bins',
+        comment='for each chirp'),
     'InstCalPar': Meta(
         name='Cal_period',
         units='s',

--- a/rpgpy/metadata.py
+++ b/rpgpy/metadata.py
@@ -377,25 +377,11 @@ METADATA = {
         name='kurtosis',
         long_name='Spectral Kurtosis',
         comment='vertical polarisation'),
-    'C1vel': Meta(
-        name='C1_velocity',
+    'velocity_vectors': Meta(
+        name='velocity_vectors',
         units='m/s',
-        long_name='Chirp 1 Doppler velocity bins',
-        comment='interpolated to maximum Doppler resolution'),
-    'C2vel': Meta(
-        name='C2_velocity',
-        units='m/s',
-        long_name='Chirp 2 Doppler velocity bins',
-        comment='interpolated to maximum Doppler resolution'),
-    'C3vel': Meta(
-        name='C3_velocity',
-        units='m/s',
-        long_name='Chirp 3 Doppler velocity bins',
-        comment='interpolated to maximum Doppler resolution'),
-    'C4vel': Meta(
-        name='C4_velocity',
-        units='m/s',
-        long_name='Chirp 4 Doppler velocity bins',
-        comment='interpolated to maximum Doppler resolution'),
+        long_name='Doppler velocity bins',
+        comment='interpolated to maximum Doppler resolution'
+    ),
 
 }

--- a/rpgpy/nc.py
+++ b/rpgpy/nc.py
@@ -67,7 +67,7 @@ def _write_initial_data(f: netCDF4.Dataset, data: dict) -> None:
     for key, array in data.items():
         if key in SKIP_ME:
             continue
-        fill_value = 0 if array.ndim > 1 else None
+        fill_value = 0 if array.ndim > 1 else -999.
         var = f.createVariable(METADATA[key].name, _get_dtype(array),
                                _get_dim(f, array), zlib=True, complevel=3,
                                shuffle=False, fill_value=fill_value)

--- a/rpgpy/nc.py
+++ b/rpgpy/nc.py
@@ -56,7 +56,7 @@ def _check_header_consistency(f, header):
 def _create_dimensions(f, header):
     f.createDimension('time', None)
     f.createDimension('range', header['RAltN'])
-    f.createDimension('spectrum', max(header['SpecN']))
+    f.createDimension('velocity', max(header['SpecN']))
     f.createDimension('chirp', header['SequN'])
 
 

--- a/rpgpy/utils.py
+++ b/rpgpy/utils.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 import numpy.ma as ma
+import numpy as np
 import datetime
 import pytz
 
@@ -75,3 +76,30 @@ def isscalar(array) -> bool:
     if not hasattr(arr, '__len__') or arr.shape == () or len(arr) == 1:
         return True
     return False
+
+
+def create_velocity_vectors(n_chirp: int, header: dict) -> list:
+    """Find level and version of RPG cloud radar binary file.
+
+    Args:
+        n_chirps (int): number of chirps
+        header (dict): Header of the radar file containing *file_code* key.
+
+    Returns:
+       list: Doppler velocity vector of each chirp
+
+    Raises:
+
+    """
+    velocity_vectors = []
+    for c in range(n_chirp):
+        n_bins = header['SpecN'][c]
+        n_bins_max = np.max(header['SpecN'])
+        bins_to_shift = (n_bins_max - n_bins)//2
+        dopp_res = np.divide(2.0 * header['MaxVel'][c], n_bins)
+        velocity_vectors.append(np.hstack((np.repeat(-999., bins_to_shift),
+                                           np.linspace(-header['MaxVel'][c] + (0.5 * dopp_res),
+                                                       +header['MaxVel'][c] - (0.5 * dopp_res),
+                                                       n_bins),
+                                           np.repeat(-999., bins_to_shift))))
+    return velocity_vectors

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -19,3 +19,10 @@ def test_rpg_seconds2date():
 ])
 def test_seconds2date(input, result):
     assert utils.rpg_seconds2date(input) == result
+
+
+def test_create_velocity_vectors():
+    inp = {'SpecN': [20], 'MaxVel': [10]}
+    res = [([-9.5, -8.5, -7.5, -6.5, -5.5, -4.5, -3.5, -2.5, -1.5, -0.5,  0.5, 1.5,  2.5,  3.5,  4.5,  5.5,  6.5,  7.5,
+             8.5,  9.5])]
+    assert_array_equal(utils.create_velocity_vectors(1, inp), res)


### PR DESCRIPTION
added a function to create an array of velocity vectors. The array has the dimensions (number of chirps, max(number of Doppler bins) ), and for those chirps with less FFT points than the maximum number of Doppler bins, the vectors are padded with fill value (-999.) on both sides so that they match the spectra array. 